### PR TITLE
Change tmux session to static floating

### DIFF
--- a/floating_plugin.tmux
+++ b/floating_plugin.tmux
@@ -16,8 +16,7 @@ set_floating_scratch_term_binding() {
 				detach-client 
 			} {
 			set -gF '@last_session_name' '#S'
-			setenv -F FLOATING_SESSION_NAME 'floating'
-			popup -d '#{pane_current_path}' -xC -yC -w70% -h70% -E 'tmux new -A -s $FLOATING_SESSION_NAME'
+			popup -d '#{pane_current_path}' -xC -yC -w70% -h70% -E 'tmux new -A -s floating'
 		}"
 	done
 }


### PR DESCRIPTION
`tmux setenv` doens't set the bash environment, so the command, "tmux new -A -s $FLOATING_SESSION_NAME" doesn't work. 

The environment variable isn't referenced anywhere else, so the simplest solution seems to be just setting "floating" directly.   I'm not entirely sure what the purpose of the setenv command was or how it worked in the past - definitely doesn't work unless (for reasons that escape me) if you source your .tmux.conf *twice* - on the second round somehow that `tmux setenv` somehow makes it's way into `$FLOATING_SESSION_NAME` - but I'm lost as to how....